### PR TITLE
Specify program name in project template CLI

### DIFF
--- a/ballet/templates/project_template/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_slug}}/__main__.py
+++ b/ballet/templates/project_template/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_slug}}/__main__.py
@@ -34,4 +34,4 @@ def engineer_features(input_dir, output_dir):
 
 
 if __name__ == '__main__':
-    cli()
+    cli(prog_name='{{ cookiecutter.package_slug }}')

--- a/tests/end_to_end/test_quickstart_end_to_end.py
+++ b/tests/end_to_end/test_quickstart_end_to_end.py
@@ -39,3 +39,10 @@ def test_quickstart_install(quickstart, virtualenv):
     virtualenv.run(
         f'python -c "import {quickstart.package_slug}"',
         capture=True)
+
+    # GH-71 CLI should be enabled and should have correct name
+    output = virtualenv.run(
+        f'python -m {quickstart.package_slug} --help',
+        capture=True
+    )
+    assert quickstart.package_slug in output


### PR DESCRIPTION
Turns out you need `prog_name`, not `name`: https://click.palletsprojects.com/en/7.x/api/?highlight=prog_name#click.BaseCommand.main

Fixes #71