### PR TITLE
Support holdout data splits to be used in validation

### DIFF
--- a/ballet/client.py
+++ b/ballet/client.py
@@ -94,7 +94,7 @@ class Client:
             self.project, 'validation.feature_accepter')
         return validate_feature_acceptance(
             accepter_class, feature, result.features, result.X_df,
-            result.y_df, result.y, False)
+            result.y_df, result.X_df, result.y, False)
 
 
 b = Client()

--- a/ballet/client.py
+++ b/ballet/client.py
@@ -87,7 +87,7 @@ class Client:
         y_df: Optional[pd.DataFrame] = None,
         subsample: bool = False
     ) -> bool:
-        """Evaluate the performance of this feature"""
+        """Evaluate the performance of this feature on the development data"""
         X_df, y_df = self._load_validation_data(X_df, y_df, subsample)
         result = self.api.engineer_features(X_df, y_df)
         accepter_class = _load_validator_class_params(

--- a/ballet/templates/project_template/{{cookiecutter.project_slug}}/ballet.yml
+++ b/ballet/templates/project_template/{{cookiecutter.project_slug}}/ballet.yml
@@ -16,6 +16,7 @@ validation:
   feature_api_validator: ballet.validation.feature_api.validator.FeatureApiValidator
   feature_accepter: ballet.validation.feature_acceptance.validator.GFSSFAccepter
   feature_pruner: ballet.validation.feature_pruning.validator.GFSSFPruner
+  split: train
 github:
   github_owner: {{ cookiecutter.github_owner }}
   remote: origin
@@ -25,7 +26,8 @@ github:
 data:
   s3_bucket:
   s3_bucket_region:
-  train: data/train
+  splits:
+    train: data/train
   entities_table_name: entities
   targets_table_name: targets
   tables:

--- a/ballet/templates/project_template/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_slug}}/load_data.py
+++ b/ballet/templates/project_template/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_slug}}/load_data.py
@@ -3,8 +3,12 @@ from ballet.util.io import load_table_from_config
 from funcy import some, where
 
 
-def load_data(input_dir=None):
-    """Load data"""
+def load_data(split='train', input_dir=None):
+    """Load data
+
+    If input dir is not None, then load whatever dataset appears in
+    `input_dir`. Otherwise, load the data split indicated by `split`.
+    """
     if input_dir is not None:
         config = load_config()
         tables = config.get('data.tables')
@@ -16,7 +20,6 @@ def load_data(input_dir=None):
         targets_table_name = config.get('data.targets_table_name')
         targets_config = some(where(tables, name=targets_table_name))
         y = load_table_from_config(input_dir, targets_config)
-    else:
-        raise NotImplementedError
+        return X, y
 
-    return X, y
+    raise NotImplementedError

--- a/ballet/validation/base.py
+++ b/ballet/validation/base.py
@@ -20,22 +20,23 @@ class FeaturePerformanceEvaluator(metaclass=ABCMeta):
     """Evaluate the performance of features from an ML point-of-view
 
     Args:
-        X_df_fit: entities frame for fitting the features
-        y_df_fit: targets frame/series for fitting the features
-        X_df_eval: entities frame for evaluating the features
-        y_eval: target values for evaluating the features
+        X_df: entities frame for fitting the features
+        y_df: targets frame/series for fitting the features
+        X_df_val: entities frame for evaluating the features
+        y_val: target values for evaluating the features
     """
 
     def __init__(self,
-                 X_df_fit: pd.DataFrame,
-                 y_df_fit: Union[pd.DataFrame, pd.Series],
-                 X_df_eval: pd.DataFrame,
-                 y_eval: np.ndarray,
+                 X_df: pd.DataFrame,
+                 y_df: Union[pd.DataFrame, pd.Series],
+                 X_df_val: pd.DataFrame,
+                 y_val: np.ndarray,
                  features: Iterable[Feature],
                  candidate_feature: Feature):
-        self.X_df = X_df_fit
-        self.y_df = y_df_fit
-        self.y = y_eval
+        self.X_df = X_df
+        self.y_df = y_df
+        self.X_df_val = X_df_val
+        self.y_val = y_val
         self.features = features
         self.candidate_feature = candidate_feature
 

--- a/ballet/validation/base.py
+++ b/ballet/validation/base.py
@@ -17,17 +17,25 @@ class BaseValidator(metaclass=ABCMeta):
 
 
 class FeaturePerformanceEvaluator(metaclass=ABCMeta):
-    """Evaluate the performance of features from an ML point-of-view"""
+    """Evaluate the performance of features from an ML point-of-view
+
+    Args:
+        X_df_fit: entities frame for fitting the features
+        y_df_fit: targets frame/series for fitting the features
+        X_df_eval: entities frame for evaluating the features
+        y_eval: target values for evaluating the features
+    """
 
     def __init__(self,
-                 X_df: pd.DataFrame,
-                 y_df: Union[pd.DataFrame, pd.Series],
-                 y: np.ndarray,
+                 X_df_fit: pd.DataFrame,
+                 y_df_fit: Union[pd.DataFrame, pd.Series],
+                 X_df_eval: pd.DataFrame,
+                 y_eval: np.ndarray,
                  features: Iterable[Feature],
                  candidate_feature: Feature):
-        self.X_df = X_df
-        self.y_df = y_df
-        self.y = y
+        self.X_df = X_df_fit
+        self.y_df = y_df_fit
+        self.y = y_eval
         self.features = features
         self.candidate_feature = candidate_feature
 

--- a/ballet/validation/feature_acceptance/__init__.py
+++ b/ballet/validation/feature_acceptance/__init__.py
@@ -2,8 +2,9 @@ from ballet.validation.common import subsample_data_for_validation
 
 
 def validate_feature_acceptance(accepter_class, feature, features, X_df, y_df,
-                                y, subsample):
+                                X_df_val, y_val, subsample):
     if subsample:
-        X_df, y_df, y = subsample_data_for_validation(X_df, y_df, y)
-    accepter = accepter_class(X_df, y_df, y, features, feature)
+        X_df, y_df, X_df_val, y_val = subsample_data_for_validation(
+            X_df, y_df, X_df_val, y_val)
+    accepter = accepter_class(X_df, y_df, X_df_val, y_val, features, feature)
     return accepter.judge()

--- a/ballet/validation/feature_acceptance/validator.py
+++ b/ballet/validation/feature_acceptance/validator.py
@@ -66,7 +66,7 @@ class GFSSFAccepter(FeatureAcceptanceMixin, GFSSFPerformanceEvaluator):
                 omit=[self.candidate_feature, omitted_feature])
 
             # Calculate CMI of candidate feature
-            cmi = estimate_conditional_information(candidate_df, self.y, z)
+            cmi = estimate_conditional_information(candidate_df, self.y_val, z)
 
             if omitted_feature is not None:
                 omit_df = feature_df_map[omitted_feature]
@@ -74,7 +74,7 @@ class GFSSFAccepter(FeatureAcceptanceMixin, GFSSFPerformanceEvaluator):
 
                 # Calculate CMI of omitted feature
                 cmi_omit = estimate_conditional_information(
-                    omit_df, self.y, z)
+                    omit_df, self.y_val, z)
             else:
                 cmi_omit = 0
                 n_omit_cols = 0

--- a/ballet/validation/feature_pruning/validator.py
+++ b/ballet/validation/feature_pruning/validator.py
@@ -54,7 +54,7 @@ class GFSSFPruner(FeaturePruningMixin, GFSSFPerformanceEvaluator):
             _, n_candidate_cols = candidate_df.shape
             z = _concat_datasets(feature_df_map, omit=[candidate_feature])
             logger.debug(CMI_MESSAGE)
-            cmi = estimate_conditional_information(candidate_df, self.y, z)
+            cmi = estimate_conditional_information(candidate_df, self.y_val, z)
 
             logger.debug(f'Conditional Mutual Information Score: {cmi}')
             statistic = cmi

--- a/ballet/validation/gfssf.py
+++ b/ballet/validation/gfssf.py
@@ -115,11 +115,11 @@ class GFSSFPerformanceEvaluator(FeaturePerformanceEvaluator):
         lambda_2_adjustment: float = LAMBDA_2_ADJUSTMENT
     ):
         super().__init__(*args)
-        self.y = asarray2d(self.y)
+        self.y_val = asarray2d(self.y_val)
         if lmbda_1 <= 0:
-            lmbda_1 = estimate_entropy(self.y) / lambda_1_adjustment
+            lmbda_1 = estimate_entropy(self.y_val) / lambda_1_adjustment
         if lmbda_2 <= 0:
-            lmbda_2 = estimate_entropy(self.y) / lambda_2_adjustment
+            lmbda_2 = estimate_entropy(self.y_val) / lambda_2_adjustment
         self.lmbda_1 = lmbda_1
         self.lmbda_2 = lmbda_2
 
@@ -135,7 +135,9 @@ class GFSSFPerformanceEvaluator(FeaturePerformanceEvaluator):
             return (
                 feature
                 .as_feature_engineering_pipeline()
-                .fit_transform(self.X_df, y=self.y_df))
+                .fit(self.X_df, y=self.y_df)
+                .transform(self.X_df_val)
+            )
 
         # map feature defintion "id" -> feature values
         feature_df_map = {

--- a/ballet/validation/main.py
+++ b/ballet/validation/main.py
@@ -153,7 +153,8 @@ def _prune_existing_features(
 
     pruner_class = _load_validator_class_params(
         project, 'validation.feature_pruner')
-    pruner = pruner_class(X_df, y_df, X_df, y, accepted_features, proposed_feature)
+    pruner = pruner_class(
+        X_df, y_df, X_df, y, accepted_features, proposed_feature)
     redundant_features = pruner.prune()
 
     # "propose removal"

--- a/ballet/validation/main.py
+++ b/ballet/validation/main.py
@@ -124,7 +124,7 @@ def _evaluate_feature_performance(project: Project, force: bool = False):
     accepter_class = _load_validator_class_params(
         project, 'validation.feature_accepter')
     accepter = accepter_class(
-        X_df, y_df, None, y, accepted_features, proposed_feature)
+        X_df, y_df, X_df, y, accepted_features, proposed_feature)
     accepted = accepter.judge()
 
     if not accepted:
@@ -153,7 +153,7 @@ def _prune_existing_features(
 
     pruner_class = _load_validator_class_params(
         project, 'validation.feature_pruner')
-    pruner = pruner_class(X_df, y_df, None, y, accepted_features, proposed_feature)
+    pruner = pruner_class(X_df, y_df, X_df, y, accepted_features, proposed_feature)
     redundant_features = pruner.prune()
 
     # "propose removal"

--- a/ballet/validation/main.py
+++ b/ballet/validation/main.py
@@ -124,7 +124,7 @@ def _evaluate_feature_performance(project: Project, force: bool = False):
     accepter_class = _load_validator_class_params(
         project, 'validation.feature_accepter')
     accepter = accepter_class(
-        X_df, y_df, y, accepted_features, proposed_feature)
+        X_df, y_df, None, y, accepted_features, proposed_feature)
     accepted = accepter.judge()
 
     if not accepted:
@@ -153,7 +153,7 @@ def _prune_existing_features(
 
     pruner_class = _load_validator_class_params(
         project, 'validation.feature_pruner')
-    pruner = pruner_class(X_df, y_df, y, accepted_features, proposed_feature)
+    pruner = pruner_class(X_df, y_df, None, y, accepted_features, proposed_feature)
     redundant_features = pruner.prune()
 
     # "propose removal"

--- a/docs/maintainer_guide.rst
+++ b/docs/maintainer_guide.rst
@@ -115,6 +115,21 @@ config file on the master branch. A contributor might accidentally modify a prot
 ``ballet.yml`` which could break the project or the CI pipeline; Repolockr will detect this and
 fail the PR which might accidentally pass otherwise.
 
+Configuring the project
+-----------------------
+
+Ballet allows you to configure many aspects of your project.
+
+Configuration is stored in the project root ``ballet.yml`` file. More details about project configuration will be added soon.
+
+Here is an incomplete list of configuration options, identified by the dotted keys from a root ``config`` object:
+
+* ``config.validation.project_structure_validator``: fully-qualified name of the class used to validate changes to the project structure
+* ``config.validation.feature_api_validator``: fully-qualified name of the class used to validate the feature API of new features
+* ``config.validation.feature_accepter``: fully-qualified name of the class used to validate the ML performance of new features
+* ``config.validation.feature_pruner``: fully-qualified name of the class used to prune existing features with respect to their ML performance
+* ``config.validation.split``: the name of the data split used for validating contributions. It will be passed as a keyword argument to your ``load_data`` function, i.e. ``load_data(split=split)``. This split should probably appear under the list at ``config.data.splits``.
+
 Developing new features
 -----------------------
 
@@ -159,17 +174,17 @@ For interactive usage:
 
 .. code-block:: python
 
-   from myproject.api import build, load_data
+   from myproject.api import api
 
    # load training data
-   X_df_tr, y_df_tr = load_data()
+   X_df_tr, y_df_tr = api.load_data()
 
    # fit pipeline to training data
-   result = build(X_df_tr, y_df_tr)
+   result = api.engineer_features(X_df_tr, y_df_tr)
    pipeline, encoder = result.pipeline, result.encoder
 
    # load new data and apply pipeline
-   X_df, y_df = load_data(input_dir='/path/to/new/data')
+   X_df, y_df = api.load_data(input_dir='/path/to/new/data')
    X = pipeline.transform(X_df)
    y = encoder.transform(y_df)
 

--- a/tests/validation/test_accepters.py
+++ b/tests/validation/test_accepters.py
@@ -16,7 +16,7 @@ def test_noop_accepter():
 
     expected = False
 
-    accepter = NeverAccepter(X_df, y_df, y, existing_features, feature)
+    accepter = NeverAccepter(X_df, y_df, None, y, existing_features, feature)
     actual = accepter.judge()
 
     assert expected == actual
@@ -31,7 +31,7 @@ def test_random_accepter(mock_uniform):
     expected = True
 
     accepter = RandomAccepter(
-        X_df, y_df, y, existing_features, candidate_feature)
+        X_df, y_df, None, y, existing_features, candidate_feature)
     actual = accepter.judge()
 
     assert expected == actual
@@ -61,6 +61,6 @@ def test_gfssf_accepter_init(sample_data):
     candidate_feature = feature_2
 
     accepter = GFSSFAccepter(
-        X_df, y_df, y, features, candidate_feature)
+        X_df, y_df, None, y, features, candidate_feature)
 
     assert accepter is not None

--- a/tests/validation/test_accepters.py
+++ b/tests/validation/test_accepters.py
@@ -16,7 +16,7 @@ def test_noop_accepter():
 
     expected = False
 
-    accepter = NeverAccepter(X_df, y_df, None, y, existing_features, feature)
+    accepter = NeverAccepter(X_df, y_df, X_df, y, existing_features, feature)
     actual = accepter.judge()
 
     assert expected == actual
@@ -31,7 +31,7 @@ def test_random_accepter(mock_uniform):
     expected = True
 
     accepter = RandomAccepter(
-        X_df, y_df, None, y, existing_features, candidate_feature)
+        X_df, y_df, X_df, y, existing_features, candidate_feature)
     actual = accepter.judge()
 
     assert expected == actual
@@ -61,6 +61,6 @@ def test_gfssf_accepter_init(sample_data):
     candidate_feature = feature_2
 
     accepter = GFSSFAccepter(
-        X_df, y_df, None, y, features, candidate_feature)
+        X_df, y_df, X_df, y, features, candidate_feature)
 
     assert accepter is not None

--- a/tests/validation/test_pruners.py
+++ b/tests/validation/test_pruners.py
@@ -19,7 +19,7 @@ def test_noop_pruner():
 
     expected = []
 
-    pruner = NoOpPruner(X_df, y_df, y, existing_features, feature)
+    pruner = NoOpPruner(X_df, y_df, None, y, existing_features, feature)
     actual = pruner.prune()
 
     assert expected == actual
@@ -36,7 +36,7 @@ def test_random_pruner(mock_uniform, mock_choice):
     X_df = y_df = y = None
     feature = None
 
-    pruner = RandomPruner(X_df, y_df, y, existing_features, feature)
+    pruner = RandomPruner(X_df, y_df, None, y, existing_features, feature)
     actual = pruner.prune()
 
     assert expected == actual
@@ -62,7 +62,7 @@ def test_gfssf_pruner_prune_exact_replicas(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, y, [feature_1], feature_2)
+        X_df, y_df, None, y, [feature_1], feature_2)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_1 in redunant_features, \
@@ -87,7 +87,7 @@ def test_gfssf_pruner_prune_weak_replicas(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, y, [feature_weak], feature_strong)
+        X_df, y_df, None, y, [feature_weak], feature_strong)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_weak in redunant_features, \
@@ -106,7 +106,7 @@ def test_gfssf_pruner_keep_relevant(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, y, [feature_1], feature_2)
+        X_df, y_df, None, y, [feature_1], feature_2)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_1 not in redunant_features, \
@@ -126,7 +126,7 @@ def test_gfssf_pruner_prune_irrelevant_features(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, y, [feature_1], feature_2)
+        X_df, y_df, None, y, [feature_1], feature_2)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_1 in redunant_features, \

--- a/tests/validation/test_pruners.py
+++ b/tests/validation/test_pruners.py
@@ -19,7 +19,7 @@ def test_noop_pruner():
 
     expected = []
 
-    pruner = NoOpPruner(X_df, y_df, None, y, existing_features, feature)
+    pruner = NoOpPruner(X_df, y_df, X_df, y, existing_features, feature)
     actual = pruner.prune()
 
     assert expected == actual
@@ -36,7 +36,7 @@ def test_random_pruner(mock_uniform, mock_choice):
     X_df = y_df = y = None
     feature = None
 
-    pruner = RandomPruner(X_df, y_df, None, y, existing_features, feature)
+    pruner = RandomPruner(X_df, y_df, X_df, y, existing_features, feature)
     actual = pruner.prune()
 
     assert expected == actual
@@ -62,7 +62,7 @@ def test_gfssf_pruner_prune_exact_replicas(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, None, y, [feature_1], feature_2)
+        X_df, y_df, X_df, y, [feature_1], feature_2)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_1 in redunant_features, \
@@ -87,7 +87,7 @@ def test_gfssf_pruner_prune_weak_replicas(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, None, y, [feature_weak], feature_strong)
+        X_df, y_df, X_df, y, [feature_weak], feature_strong)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_weak in redunant_features, \
@@ -106,7 +106,7 @@ def test_gfssf_pruner_keep_relevant(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, None, y, [feature_1], feature_2)
+        X_df, y_df, X_df, y, [feature_1], feature_2)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_1 not in redunant_features, \
@@ -126,7 +126,7 @@ def test_gfssf_pruner_prune_irrelevant_features(sample_data):
         transformer=IdentityTransformer(),
         source='2nd Feature')
     gfssf_pruner = GFSSFPruner(
-        X_df, y_df, None, y, [feature_1], feature_2)
+        X_df, y_df, X_df, y, [feature_1], feature_2)
 
     redunant_features = gfssf_pruner.prune()
     assert feature_1 in redunant_features, \


### PR DESCRIPTION
Can use the `validation.split` setting to specify a data split to be used in validation (i.e. `test` or `holdout`). The only significance of this setting is that data will be loaded using `load_data(split=split)` during validation. (Note that the pipeline and encoder will still be fit on the training data.) If your `load_data` function does not support loading a split by name, then ballet will fall back to using the training split.