### PR TITLE
Add primitives to use Ballet together with MLBlocks

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,9 +5,9 @@ include LICENSE
 include README.md
 
 recursive-include tests *
+recursive-include ballet/templates *
+recursive-include ballet/mlprimitives *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
-
-recursive-include ballet/templates *

--- a/ballet/encoder.py
+++ b/ballet/encoder.py
@@ -11,20 +11,40 @@ class EncoderPipeline(TransformerPipeline):
     ``y`` to their fit and transform methods. This is needed because some
     consumers like MLBlocks passes arguments by keyword, and we need to pass an
     argument named ``y`` rather than one named ``X``.
+
+    Args:
+        can_skip_transform_none: behavior if during the transform stage, the
+            input y is None (as would be the case during the ``predict`` stage
+            of an MLPipeline). If false (the default), then we call the
+            pipeline's transform method on y. If true, we skip calling the
+            transform method and instead return immediately (returning the
+            value ``None``).
     """
+
+    def __init__(self, *args, can_skip_transform_none=False, **kwargs):
+        self.can_skip_transform_none = can_skip_transform_none
+        super().__init__(*args, **kwargs)
+
     def fit(self, y, **fit_params):
         return super().fit(X=y, **fit_params)
 
     def transform(self, y):
+        if self.can_skip_transform_none and y is None:
+            return None
         return super().transform(X=y)
 
+    def fit_transform(self, y, **fit_params):
+        return self.fit(y, **fit_params).transform(y)
 
-def make_encoder_pipeline(steps):
-    return EncoderPipeline(ballet.transformer._name_estimators(steps))
+
+def make_encoder_pipeline(steps, **kwargs):
+    return EncoderPipeline(
+        ballet.transformer._name_estimators(steps), **kwargs)
 
 
 def make_robust_encoder(
     steps: OneOrMore[TransformerLike],
+    **kwargs,
 ):
     if not isinstance(steps, list):
         steps = [steps]
@@ -32,4 +52,4 @@ def make_robust_encoder(
         ballet.transformer.make_robust_transformer(step)
         for step in steps
     ]
-    return make_encoder_pipeline(steps)
+    return make_encoder_pipeline(steps, **kwargs)

--- a/ballet/mlprimitives/__init__.py
+++ b/ballet/mlprimitives/__init__.py
@@ -1,0 +1,56 @@
+import pathlib
+from copy import deepcopy
+from typing import Optional
+
+from ballet.encoder import EncoderPipeline, make_robust_encoder
+from ballet.pipeline import FeatureEngineeringPipeline
+from ballet.project import Project
+from ballet.util.mod import import_module_from_modname
+
+PRIMITIVES_PATH = [pathlib.Path(__file__).with_name('primitives').resolve()]
+PIPELINES_PATH = [pathlib.Path(__file__).with_name('pipelines').resolve()]
+
+
+def _get_project(package_slug, project_path):
+    if package_slug is not None:
+        package = import_module_from_modname(package_slug)
+        return Project(package)
+    elif project_path is not None:
+        return Project.from_path(project_path)
+    else:
+        return Project.from_cwd()
+
+
+def make_engineer_features(
+    package_slug: Optional[str] = None,
+    project_path: Optional[str] = None
+) -> FeatureEngineeringPipeline:
+    """Make the engineer_features primitive for the given Ballet project
+
+    The primitive detects the Ballet project in one of three ways. First, if
+    the package slug is given, then Ballet will import the package and detect
+    the project. Second, if a path to the project is given (i.e. the directory
+    containing the ballet.yml configuration file), then the project will be
+    detected that way. Third, if neither is given, then Ballet will try to
+    detect a project in the current working directory. This third option is the
+    least robust and sensitive to where you are running the MLPipeline from.
+
+    Args:
+        package_slug: name of top-level package for the Ballet project
+        project_path: filesystem path to the directory containing a valid
+          ballet.yml configuration file
+
+    Returns:
+        a deepcopy of the feature engineering pipeline defined by the project
+    """
+    project = _get_project(package_slug, project_path)
+    return deepcopy(project.api.pipeline)
+
+
+def make_encode_target(
+    package_slug: Optional[str] = None,
+    project_path: Optional[str] = None
+) -> EncoderPipeline:
+    project = _get_project(package_slug, project_path)
+    encoder = deepcopy(project.api.encoder)
+    return make_robust_encoder(encoder, can_skip_transform_none=True)

--- a/ballet/mlprimitives/pipelines/ballet_rf_classifier.json
+++ b/ballet/mlprimitives/pipelines/ballet_rf_classifier.json
@@ -1,0 +1,12 @@
+{
+    "metadata": {
+        "name": "ballet_rf_classifier",
+        "data_type": "single_table",
+        "task_type": "classification"
+    },
+    "primitives": [
+        "ballet.engineer_features",
+        "ballet.encode_target",
+        "sklearn.ensemble.RandomForestClassifier"
+    ]
+}

--- a/ballet/mlprimitives/pipelines/ballet_rf_regressor.json
+++ b/ballet/mlprimitives/pipelines/ballet_rf_regressor.json
@@ -1,0 +1,12 @@
+{
+    "metadata": {
+        "name": "ballet_rf_regressor",
+        "data_type": "single_table",
+        "task_type": "regression"
+    },
+    "primitives": [
+        "ballet.engineer_features",
+        "ballet.encode_target",
+        "sklearn.ensemble.RandomForestRegressor"
+    ]
+}

--- a/ballet/mlprimitives/primitives/ballet.encode_target.json
+++ b/ballet/mlprimitives/primitives/ballet.encode_target.json
@@ -1,0 +1,40 @@
+{
+    "name": "ballet.encode_target",
+    "contributors": [
+        "Micah Smith <micahs@mit.edu>"
+    ],
+    "documentation": "",
+    "description": "Applies the target encoder from the given Ballet project",
+    "classifiers": {
+        "type": "preprocessor",
+        "subtype": "data_cleanup"
+    },
+    "modalities": [],
+    "primitive": "ballet.mlprimitives.make_encode_target",
+    "fit": {
+        "method": "fit",
+        "args": [
+            {
+                "name": "y",
+                "type": "pandas.DataFrame"
+            }
+        ]
+    },
+    "produce": {
+        "method": "transform",
+        "args": [
+            {
+                "name": "y",
+                "default": null,
+               "type": "pandas.DataFrame"
+            }
+        ],
+        "output": [
+            {
+                "name": "y",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "hyperparameters": {}
+}

--- a/ballet/mlprimitives/primitives/ballet.engineer_features.json
+++ b/ballet/mlprimitives/primitives/ballet.engineer_features.json
@@ -1,0 +1,43 @@
+{
+    "name": "ballet.engineer_features",
+    "contributors": [
+        "Micah Smith <micahs@mit.edu>"
+    ],
+    "documentation": "",
+    "description": "Applies the feature engineering pipeline from the given Ballet project",
+    "classifiers": {
+        "type": "preprocessor",
+        "subtype": "transformer"
+    },
+    "modalities": [],
+    "primitive": "ballet.mlprimitives.make_engineer_features",
+    "fit": {
+        "method": "fit",
+        "args": [
+            {
+                "name": "X",
+                "type": "pandas.DataFrame"
+            },
+            {
+                "name": "y",
+                "type": "pandas.DataFrame"
+            }
+        ]
+    },
+    "produce": {
+        "method": "transform",
+        "args": [
+            {
+                "name": "X",
+                "type": "pandas.DataFrame"
+            }
+        ],
+        "output": [
+            {
+                "name": "X",
+                "type": "pandas.DataFrame"
+            }
+        ]
+    },
+    "hyperparameters": {}
+}

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,10 @@ setup(
         'console_scripts': [
             'ballet=ballet.cli:cli',
         ],
+        'mlblocks': [
+            'primitives=ballet.mlprimitives:PRIMITIVES_PATH',
+            'pipelines=ballet.mlprimitives:PIPELINES_PATH',
+        ],
     },
     extras_require={
         'test': test_requirements,

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -5,7 +5,6 @@ from ballet.encoder import make_robust_encoder
 from ballet.eng import IdentityTransformer
 from ballet.util.testing import assert_series_equal
 
-
 with_encoder = pytest.mark.parametrize(
     'encoder',
     [


### PR DESCRIPTION
* the `ballet.engineer_features` primitive applies a given project's feature engineering pipeline
* the `ballet.encode_target` primitive applies a given project's target encoder
* two sample pipelines are included that put these two steps together with either RF classifier or regressor
* a `ballet.decode_target` primitive may be necessary in the future but is not implemented here: (1) the target encoder is not necessarily reversible (2) the primitive needs to be able to restore its state from the context similar to class decoder

Example usage (for *predict-census-income*):
```python
import mlblocks
from ballet import b
from sklearn.metrics import classification_report

X_df, y_df = b.api.load_data()
X_df_te, y_df_te = b.api.load_data(input_dir='data/val')

encoder = b.api.encoder
y = encoder.fit_transform(y_df)
y_te = encoder.transform(y_df_te)

pipeline_info = mlblocks.load_pipeline('ballet_rf_classifier')
pipeline = mlblocks.MLPipeline(pipeline_info)

pipeline.fit(X_df, y_df)

y_pred = pipeline.predict(X_df)
report = classification_report(y, y_pred, output_dict=True)

y_pred_te = pipeline.predict(X_df_te)
report_te = classification_report(y_te, y_pred_te, output_dict=True)
```